### PR TITLE
Fix coloring of brackets and variables

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -119,7 +119,7 @@ atom-text-editor.is-focused, :host(.is-focused) {
     color: rgba(255, 83, 112, 1);
 }
 .entity.name.function, .meta.require, .support.function.any-method,
-.meta.function-call, .support.function, .keyword.other.special-method,
+.support.function, .keyword.other.special-method,
 .meta.block-level {
     color: #82b1ff;
     top: 10px;


### PR DESCRIPTION
Fixes silvestreh/atom-material-syntax#27
A bunch of non-functions were being colored like functions
